### PR TITLE
Fix screen sharing staying broken after returning from Gaming Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,15 +440,19 @@ See [Recovery from a Black Screen](#recovery-from-a-black-screen) for how to get
 
 **Screen sharing in Chromium / Firefox is broken after returning from Gaming Mode (only "Share a tab" works)**
 
-Root cause: `xdg-desktop-portal-hyprland` (and the pipewire stack behind it) is still bound to the killed Hyprland instance after the SDDM restart. Tab capture in Chromium works because it bypasses the portal entirely; screen and window capture go through services that need to be reattached to the live compositor. (On pre-4 Omarchy the same stale-socket problem also killed the clipboard via Walker's `elephant.service`; Omarchy 4's shell starts fresh each session, so the clipboard is unaffected there.)
+Root cause: while the gamescope session is running, Steam D-Bus-activates `xdg-desktop-portal` inside it. That instance comes up with almost no environment — no `XDG_CURRENT_DESKTOP` — so it can't match a backend and falls back to GTK. It's still running when your Hyprland session returns, so nothing restarts it, it never learns it's on Hyprland, and it never activates `xdg-desktop-portal-hyprland`. With no screencast backend, the source picker is never spawned and the share dialog just sits there. Tab capture works because Chromium does it internally, without the portal.
 
-DeckShift handles this automatically via `/usr/local/bin/deckshift-portal-recovery`, autostarted from `~/.config/hypr/autostart.lua` (Omarchy 4) or `autostart.conf` (pre-4). **If you installed before v0.1.15 and are on Omarchy 4, re-run `./deckshift.sh`** — the old `autostart.conf` wiring is ignored by Omarchy 4's Lua config provider, so the helper never ran. You can also run the recovery manually:
+To confirm: `systemctl --user is-active xdg-desktop-portal-hyprland.service` returns `inactive`.
+
+DeckShift handles this automatically via `/usr/local/bin/deckshift-portal-recovery`, autostarted from `~/.config/hypr/autostart.lua` (Omarchy 4) or `autostart.conf` (pre-4). **If you installed before v0.2.1, re-run `./deckshift.sh`** — earlier versions wrote the trigger marker too late in `switch-to-desktop` to ever survive, so the helper no-oped on every return. If you're on a pre-v0.1.15 install and on Omarchy 4, re-running also fixes the `autostart.conf` wiring, which Omarchy 4's Lua config provider ignores.
+
+To fix a session that's already broken, without a re-login:
 
 ```bash
-touch /tmp/.deckshift-just-returned && /usr/local/bin/deckshift-portal-recovery
+systemctl --user restart xdg-desktop-portal.service
 ```
 
-then re-open the browser tab. (The `touch` is needed because the helper is a no-op without the marker file — that's deliberate, so it doesn't bounce portals on every normal login.)
+then re-open the browser tab. Running `/usr/local/bin/deckshift-portal-recovery` by hand does the same thing plus the GTK backend — since v0.2.1 it detects the bad state on its own, so it no longer needs the marker file to be touched first.
 
 **Suspend fails with "Access denied" after returning from Gaming Mode**
 

--- a/deckshift.sh
+++ b/deckshift.sh
@@ -2228,20 +2228,29 @@ enable_performance_mode() {
 restore_balanced_mode() {
     log "Restoring pre-Gaming-Mode state..."
 
-    # Read what the user's state actually was before Gaming Mode; fall back
-    # to safe defaults if the saved-state file is missing.
-    local saved_cpu_gov="" saved_pp=""
+    # Read what the user's state actually was before Gaming Mode.
+    #
+    # A missing saved-state file does NOT mean "guess safe defaults" — it means
+    # switch-to-desktop already consumed the file and restored the real values
+    # on its way out. Writing powersave/balanced on top of that clobbers a
+    # correct restore with a guess, which is wrong on any machine whose normal
+    # state is something else (schedutil, or performance on a desktop). So the
+    # governor and profile are only touched when we actually know the values.
+    local saved_cpu_gov="" saved_pp="" have_saved_state=0
     if [[ -f "$SAVED_STATE_FILE" ]]; then
         # shellcheck disable=SC1090
         source "$SAVED_STATE_FILE"
         saved_cpu_gov="${PRE_GAMING_CPU_GOVERNOR:-}"
         saved_pp="${PRE_GAMING_POWER_PROFILE:-}"
+        have_saved_state=1
     fi
 
     local target_gov="${saved_cpu_gov:-powersave}"
-    for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
-        echo "$target_gov" > "$gov" 2>/dev/null
-    done
+    if (( have_saved_state )); then
+        for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+            echo "$target_gov" > "$gov" 2>/dev/null
+        done
+    fi
 
     # NVIDIA dGPU restore
     if command -v nvidia-smi &>/dev/null; then
@@ -2263,18 +2272,29 @@ restore_balanced_mode() {
         sudo -n nvidia-smi -pm 0 2>/dev/null
     fi
 
-    # Restore power profile (saved value, or balanced fallback)
-    if command -v powerprofilesctl &>/dev/null; then
+    # Restore power profile — same rule as the governor above.
+    if (( have_saved_state )) && command -v powerprofilesctl &>/dev/null; then
         local target_pp="${saved_pp:-balanced}"
         sudo -n powerprofilesctl set "$target_pp" 2>/dev/null || \
             powerprofilesctl set "$target_pp" 2>/dev/null
     fi
 
     rm -f "$SAVED_STATE_FILE"
-    log "Pre-Gaming-Mode state restored (governor=$target_gov profile=${saved_pp:-balanced})"
+    if (( have_saved_state )); then
+        log "Pre-Gaming-Mode state restored (governor=$target_gov profile=${saved_pp:-balanced})"
+    else
+        log "No saved state to restore (already restored by switch-to-desktop); GPU state reset only"
+    fi
 }
 
 cleanup() {
+    # Guard against re-entry. The trap fires on EXIT *and* on the signal that
+    # caused the exit, so on a normal Gaming Mode exit this ran three times in
+    # the same second — each later pass finding the saved-state file already
+    # deleted by the first.
+    [[ -n "${DECKSHIFT_CLEANUP_DONE:-}" ]] && return 0
+    DECKSHIFT_CLEANUP_DONE=1
+
     pkill -f steam-library-mount 2>/dev/null || true
     pkill -f gaming-keybind-monitor 2>/dev/null || true
     sudo -n /usr/local/bin/gamescope-nm-stop 2>/dev/null || true
@@ -2458,6 +2478,19 @@ if [[ ! -f /tmp/.gaming-session-active ]]; then
 fi
 rm -f /tmp/.gaming-session-active
 
+# Marker for the next Hyprland startup — tells deckshift-portal-recovery that
+# we are returning from Gaming Mode and the xdg-desktop-portal stack needs a
+# kick. /tmp survives the session switch; /run/user does not.
+#
+# This MUST be written before anything below touches gamescope. This script
+# runs inside the gamescope session's SDDM scope (sddm-helper -> wrapper ->
+# gaming-keybind-monitor -> here), so the `pkill gamescope` further down ends
+# the very session it lives in: the wrapper exits, SDDM closes the session and
+# systemd tears the scope down, killing this script with it. Written at the end
+# (where it used to live) the touch was never reached, so the recovery helper
+# saw no marker and no-oped on every single return.
+touch /tmp/.deckshift-just-returned 2>/dev/null || true
+
 # SYNCHRONOUS POWER RESTORE — done first because the trap-based restore in
 # gamescope-session-nm-wrapper can be SIGKILL'd by `systemctl restart sddm`
 # before it completes, leaving CPU governor / power profile stuck at
@@ -2509,14 +2542,18 @@ fi
 
 sleep 2
 
-# Marker for the next Hyprland startup — tells deckshift-portal-recovery
-# that we're returning from Gaming Mode and the xdg-desktop-portal stack
-# needs a kick. Without this, Chromium/Firefox screen-sharing on Wayland
-# silently fails (only tab-sharing works) because the portal is still bound
-# to the killed Hyprland instance. /tmp survives SDDM restart; /run/user
-# does not (logind tears down the user manager).
-touch /tmp/.deckshift-just-returned 2>/dev/null || true
-
+# Fallback return path. On a stock DeckShift install these two lines are
+# normally never reached: killing gamescope above ends this script's own SDDM
+# session scope, and SDDM's `Relogin=true` (written by the installer into
+# /etc/sddm.conf.d/zz-gaming-session.conf) logs straight back into the session
+# name `gaming-session-switch desktop` already selected, so the desktop returns
+# without any help from here.
+#
+# They are kept for installs where the session does not end on its own —
+# without them the user would be left staring at gamescope's dead output. Do
+# not background/disown the restart to "make it survive": on a Relogin=true
+# system it would then fire a second time and kill the Hyprland session that
+# just came up.
 sudo -n chvt 2 2>/dev/null || true
 sleep 0.5
 # Atomic restart — stop+start (with stop and start as separate sudo calls)
@@ -2635,63 +2672,113 @@ KEYBIND_MONITOR
 
   # Portal Recovery Helper — runs at every Hyprland startup
   #
-  # When switch-to-desktop restarts SDDM, the new Hyprland instance gets a
-  # fresh HYPRLAND_INSTANCE_SIGNATURE, but xdg-desktop-portal-hyprland (and
-  # the pipewire stack) may still be bound to the old, dead instance. The
-  # symptom is Chromium/Firefox "Share desktop / window" failing silently on
-  # Google Meet etc. while "Share a tab" still works (because tab capture
-  # bypasses the portal entirely).
+  # Symptom: after returning from Gaming Mode, "Share screen" in Chromium /
+  # Firefox does nothing at all — the source picker never appears. Sharing a
+  # tab still works, because tab capture bypasses the portal entirely.
   #
-  # switch-to-desktop drops /tmp/.deckshift-just-returned right before the
-  # SDDM restart. This helper, run as exec-once from Hyprland's autostart,
-  # checks for that marker on every Hyprland start, and if present, bounces
-  # the portal + pipewire user services so they reattach to the live HIS.
-  # No marker = no-op (cheap; runs in milliseconds).
+  # Cause (measured on Omarchy 4.0.0 / xdg-desktop-portal 1.22.1): the portal
+  # teardown at session exit is correct — every portal unit is
+  # PartOf=graphical-session.target and stops cleanly. Two seconds later,
+  # while the gamescope session is coming up, *Steam* D-Bus-activates
+  # xdg-desktop-portal. That instance starts with almost no environment (its
+  # entire /proc/PID/environ is `XDG_RUNTIME_DIR=/run/user/1000` — no
+  # XDG_CURRENT_DESKTOP, no WAYLAND_DISPLAY), so it cannot match a backend
+  # from portals.conf and logs "Choosing gtk.portal ... as a last-resort
+  # fallback"; the GTK backend then dies with "cannot open display".
   #
-  # The recovery sequence is ordered to avoid a race that earlier versions
-  # hit when restarting all five services simultaneously: portals could come
-  # up before wireplumber had finished building the node graph, so the
-  # screencast portal would bind to nothing. We now (a) push live session
-  # env into D-Bus + systemd --user so portals activate against the new
-  # Wayland socket, (b) stop portals first, (c) restart pipewire and wait
-  # for the graph, (d) start portals last. (Pre-Omarchy-4 versions also
-  # restarted Walker/elephant to reattach the clipboard listener; Omarchy 4's
-  # omarchy-shell owns the clipboard and starts fresh with each session, so
-  # that step is gone.)
+  # When Hyprland comes back that frontend is still `active`, so nothing
+  # restarts it. It never re-reads portals.conf, never learns
+  # XDG_CURRENT_DESKTOP=Hyprland, and therefore never activates
+  # xdg-desktop-portal-hyprland — which stays `inactive (dead)` for the rest
+  # of the session, leaving no screencast backend at all.
+  #
+  # It survives because the user manager is never torn down: the gamescope
+  # session runs as the same user, so user@UID.service keeps running even
+  # with Linger=no. For the same reason the pipewire graph is untouched by
+  # the round-trip, which is why this helper no longer restarts it.
+  #
+  # The fix is to restart the *frontend*; it then re-activates the Hyprland
+  # backend by itself. The helper triggers on the marker dropped by
+  # switch-to-desktop, or — so a lost marker cannot silently disable the whole
+  # mechanism — on directly detecting a poisoned frontend. No trigger = no-op.
   info "Creating portal recovery helper..."
   local portal_recovery="/usr/local/bin/deckshift-portal-recovery"
 
   sudo tee "$portal_recovery" > /dev/null << 'PORTAL_RECOVERY'
 #!/bin/bash
-[[ -f /tmp/.deckshift-just-returned ]] || exit 0
-rm -f /tmp/.deckshift-just-returned
+# DeckShift — repair the xdg-desktop-portal stack after Gaming Mode.
+# See the comment above this heredoc in deckshift.sh for the full analysis.
 
-# Give the new Hyprland a moment to fully come up and export its env to the
-# user manager (HYPRLAND_INSTANCE_SIGNATURE / WAYLAND_DISPLAY).
-sleep 2
+marker=/tmp/.deckshift-just-returned
+returned=0
+if [[ -f $marker ]]; then
+  returned=1
+  rm -f "$marker"
+fi
 
-# Pull the live session env into systemd --user and the D-Bus activation env,
-# so D-Bus-activated portals bind to the new Wayland socket, not the dead one
-# left over from the gamescope session.
-systemctl --user import-environment WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE 2>/dev/null || true
-dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE 2>/dev/null || true
+# Wait for uwsm/Hyprland to publish the session env to the user manager,
+# rather than guessing with a fixed sleep.
+for _ in {1..20}; do
+  systemctl --user show-environment 2>/dev/null \
+    | grep -q '^HYPRLAND_INSTANCE_SIGNATURE=' && break
+  sleep 0.5
+done
 
-# Stop portals first so they don't try to talk to a half-restarted pipewire.
-systemctl --user stop xdg-desktop-portal-hyprland.service xdg-desktop-portal.service 2>/dev/null || true
-# Kill any zombies left over from gamescope's session (SIGTERM, then SIGKILL
-# only for stragglers — SIGKILL alone leaves stale D-Bus name registrations).
-pkill -TERM -x xdg-desktop-portal-hyprland xdg-desktop-portal xdg-desktop-portal-wlr 2>/dev/null
-sleep 0.5
-pkill -KILL -x xdg-desktop-portal-hyprland xdg-desktop-portal xdg-desktop-portal-wlr 2>/dev/null
-systemctl --user reset-failed xdg-desktop-portal-hyprland.service xdg-desktop-portal.service 2>/dev/null || true
+# A healthy xdg-desktop-portal inherits XDG_CURRENT_DESKTOP from the session
+# and, under Hyprland, the current HYPRLAND_INSTANCE_SIGNATURE. One activated
+# by Steam inside gamescope has neither.
+#
+# Checking the frontend's own environment rather than "frontend up, backend
+# down" matters: the latter is briefly true during every normal login, while
+# this signature is unambiguous and never fires on a clean boot.
+portal_poisoned() {
+  local pid xdp_his
+  pid=$(systemctl --user show -p MainPID --value xdg-desktop-portal.service 2>/dev/null)
+  [[ -n $pid && $pid != 0 && -r /proc/$pid/environ ]] || return 1
 
-# Restart pipewire stack and wait for wireplumber to rebuild the node graph
-# before portals come back up (otherwise screencast portal binds to nothing).
-systemctl --user restart pipewire.service pipewire-pulse.service wireplumber.service 2>/dev/null || true
-sleep 2
+  tr '\0' '\n' < "/proc/$pid/environ" | grep -q '^XDG_CURRENT_DESKTOP=' || return 0
 
-# Now bring portals up cleanly.
-systemctl --user start xdg-desktop-portal-hyprland.service xdg-desktop-portal.service 2>/dev/null || true
+  if [[ -n ${HYPRLAND_INSTANCE_SIGNATURE:-} ]]; then
+    xdp_his=$(tr '\0' '\n' < "/proc/$pid/environ" \
+              | sed -n 's/^HYPRLAND_INSTANCE_SIGNATURE=//p')
+    [[ $xdp_his != "$HYPRLAND_INSTANCE_SIGNATURE" ]] && return 0
+  fi
+  return 1
+}
+
+if (( ! returned )) && ! portal_poisoned; then
+  exit 0
+fi
+
+# Push the live session vars into the systemd/D-Bus activation environment.
+# HYPRLAND_INSTANCE_SIGNATURE is included deliberately: Omarchy's screen-share
+# picker (hyprland-preview-share-picker, wired up via xdph.conf's
+# custom_picker_binary) opens the Hyprland IPC socket itself and exits without
+# ever drawing a window if that variable is missing.
+VARS="WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE XDG_SESSION_DESKTOP HYPRLAND_INSTANCE_SIGNATURE"
+# shellcheck disable=SC2086
+systemctl --user import-environment $VARS 2>/dev/null || true
+# shellcheck disable=SC2086
+dbus-update-activation-environment --systemd $VARS 2>/dev/null || true
+
+# Stop the backends, then restart the frontend. On restart it re-reads
+# portals.conf with a correct XDG_CURRENT_DESKTOP and D-Bus-activates the
+# Hyprland backend. The GTK backend is included because gamescope-side
+# activation leaves it failed ("cannot open display", status=1/FAILURE), and
+# it is the fallback for every interface xdph does not implement
+# (hyprland-portals.conf: default=hyprland;gtk).
+systemctl --user stop \
+  xdg-desktop-portal-hyprland.service \
+  xdg-desktop-portal-gtk.service 2>/dev/null || true
+systemctl --user reset-failed \
+  xdg-desktop-portal.service \
+  xdg-desktop-portal-hyprland.service \
+  xdg-desktop-portal-gtk.service 2>/dev/null || true
+systemctl --user restart xdg-desktop-portal.service 2>/dev/null || true
+
+# Nudge the Hyprland backend up in case nothing has requested a portal yet.
+sleep 1
+systemctl --user start xdg-desktop-portal-hyprland.service 2>/dev/null || true
 PORTAL_RECOVERY
 
   sudo chmod +x "$portal_recovery"


### PR DESCRIPTION
# Fix screen sharing staying broken after returning from Gaming Mode

Screen sharing in Chromium/Firefox is dead after a Gaming Mode round-trip — the
source picker never appears at all, and only "Share a tab" works.
`deckshift-portal-recovery` is meant to prevent exactly this, but it never runs,
and even when forced to run it repairs the wrong thing.

Measured and verified on a live system: Omarchy 4.0.0, Hyprland 0.56.2,
xdg-desktop-portal 1.22.1, xdg-desktop-portal-hyprland 1.4.1, uwsm 0.26.6,
hyprland-preview-share-picker 0.2.1, SDDM autologin with `Relogin=true`.

Full evidence (journal excerpts, `/proc/PID/environ` dumps, before/after PIDs) is
in `PORTAL-RECOVERY-FINDINGS.md`, filed alongside this as an issue.

---

## 1. `switch-to-desktop` never wrote its marker

The script runs inside the gamescope session's SDDM scope:

```
sddm-helper → gamescope-session-nm-wrapper → gaming-keybind-monitor → switch-to-desktop
```

Its own `pkill gamescope` ends that session. The wrapper exits, SDDM closes the
session, systemd tears the scope down, and `switch-to-desktop` is killed with it
— during the `sleep 2` that sits **two lines above**
`touch /tmp/.deckshift-just-returned`.

Journal evidence, one real round-trip. Everything up to `rfkill` runs; the tail
never appears:

| script line | command | in journal |
|---|---|---|
| 31/32 | `systemctl unmask sleep.target …` | ✅ 18:16:00 |
| 34 | `gaming-session-switch desktop` | ✅ 18:16:01 |
| 37 | `rfkill unblock bluetooth` | ✅ 18:16:01 |
| **64** | **`touch /tmp/.deckshift-just-returned`** | **✗ never ran** |
| 66 | `sudo -n chvt 2` | ✗ never ran |
| 72 | `sudo -n systemctl restart sddm` | ✗ never ran |

This is invisible in normal use: SDDM's `Relogin=true` logs straight back into
the session name `gaming-session-switch desktop` already selected, so the desktop
returns anyway. Only the marker is missing — and so
`deckshift-portal-recovery` exits at line 2 on **every** return.

**Fix:** write the marker immediately, before anything touches gamescope.

I left the trailing `chvt 2` / `systemctl restart sddm` in place, since they are
still the return path on installs where the session does not end by itself, and
only replaced the comment above them (which described the old, now-inaccurate
reasoning). Worth noting for anyone tempted to "fix" them later: backgrounding
or disowning that restart so it survives the teardown would be actively harmful
on a `Relogin=true` system — it would fire a second time and kill the Hyprland
session that just came up.

## 2. The recovery helper targeted a failure that does not happen

The helper assumed `xdg-desktop-portal-hyprland` was left bound to a dead
Hyprland instance with a stale `HYPRLAND_INSTANCE_SIGNATURE`. It is not — every
portal unit is `PartOf=graphical-session.target` and stops cleanly at session
exit:

```
18:15:43 systemd[1310]: Stopping Portal service (Hyprland implementation)...
18:15:43 systemd[1310]: Stopped Portal service.
```

Two seconds later, **Steam D-Bus-activates `xdg-desktop-portal` inside the
gamescope session**:

```
18:15:46 systemd[1310]: Starting Portal service...
18:15:46 xdg-desktop-portal[34508]: Choosing gtk.portal for
          org.freedesktop.impl.portal.Lockdown as a last-resort fallback
18:15:46 xdg-desktop-portal-gtk[34527]: cannot open display:
18:15:46 systemd[1310]: xdg-desktop-portal-gtk.service: Main process exited, status=1/FAILURE
```

That instance has essentially no environment. Its **entire** `/proc/34508/environ`:

```
XDG_RUNTIME_DIR=/run/user/1000
```

No `XDG_CURRENT_DESKTOP`, no `WAYLAND_DISPLAY` — hence the "last-resort
fallback", and hence the GTK backend dying for want of a display.

When Hyprland returns, that frontend is **still `active`**, so nothing restarts
it. It never re-reads `portals.conf`, never learns
`XDG_CURRENT_DESKTOP=Hyprland`, and never activates
`xdg-desktop-portal-hyprland` — which stays `inactive (dead)` for the rest of the
session. No screencast backend exists, so the picker is never spawned and the
share dialog just sits there.

It survives the round-trip because the user manager is never torn down: the
gamescope session runs as the *same user*, so `user@UID.service` keeps running
even with `Linger=no`.

**Fix:** restart the *frontend*; it re-activates the Hyprland backend by itself.
Concretely the helper now:

- restarts `xdg-desktop-portal.service`, and bounces
  `xdg-desktop-portal-gtk.service` too — gamescope-side activation leaves it
  failed, and it is the fallback for every interface xdph does not implement
  (`hyprland-portals.conf`: `default=hyprland;gtk`)
- includes `HYPRLAND_INSTANCE_SIGNATURE` in the env push. Omarchy wires
  `custom_picker_binary = hyprland-preview-share-picker` in `xdph.conf`, and that
  picker opens the Hyprland IPC socket itself — its binary carries
  `Could not get socket path! (Is Hyprland running??)`. Without that variable it
  exits before drawing a window, which looks identical to this bug
- waits for that variable to appear in `systemctl --user show-environment`
  instead of a fixed `sleep 2`
- **self-triggers** when it detects a poisoned frontend, so a lost marker can
  never silently disable the whole mechanism again. The check is the frontend's
  own environment (missing `XDG_CURRENT_DESKTOP`, or a stale HIS), not
  "frontend up, backend down" — the latter is briefly true during every normal
  login and would cause false positives
- **drops the pipewire/wireplumber restart.** The audio graph is untouched by the
  round-trip for the reason above, so bouncing it only disconnects every audio
  client. It also raced `wireplumber.service`'s `BindsTo=pipewire.service`

## 3. `cleanup()` ran three times per exit and clobbered a correct power restore

Found while tracing bug 1. `trap cleanup EXIT INT TERM` in
`gamescope-session-nm-wrapper` has no re-entrancy guard, so it fires three times
in the same second:

```
18:16:02 gamescope-wrapper[35990]: Restoring pre-Gaming-Mode state...
18:16:02 gamescope-wrapper[36031]: Pre-Gaming-Mode state restored (governor=powersave profile=balanced)
18:16:02 gamescope-wrapper[36039]: Restoring pre-Gaming-Mode state...
18:16:02 gamescope-wrapper[36052]: Pre-Gaming-Mode state restored (governor=powersave profile=balanced)
18:16:02 gamescope-wrapper[36062]: Restoring pre-Gaming-Mode state...
18:16:02 gamescope-wrapper[36075]: Pre-Gaming-Mode state restored (governor=powersave profile=balanced)
```

`restore_balanced_mode()` treats a missing saved-state file as "fall back to
`powersave`/`balanced`" — but by then the file is *always* gone.
`switch-to-desktop` consumes and deletes it at the top of its run (that part does
execute, it is above the `pkill`), and the first cleanup pass deletes it too. So
every pass after the first overwrites a correct restore with a guess, and the
governor is world-writable after install, so those writes land.

`powersave`/`balanced` is wrong on any machine whose normal state is something
else — `schedutil`, or `performance` on a desktop. On my box the damage was
masked because Omarchy's own `omarchy-powerprofiles-init` re-applies the AC
profile a couple of seconds later; without that the user is left on `powersave`
after every session.

**Fix:** re-entrancy guard on `cleanup()`, and skip the governor/profile writes
entirely when there is no saved state to read rather than guessing. The NVIDIA
reset stays unconditional.

---

## Verification

A single command restores screen sharing on a session broken by the round-trip,
which is the whole diagnosis in one line:

```
$ systemctl --user restart xdg-desktop-portal.service
$ systemctl --user is-active xdg-desktop-portal-hyprland.service
active
```
```
20:32:10 systemd[1310]: Started Portal service (Hyprland implementation).
20:32:10 xdg-desktop-portal-hyprland[106229]: [LOG] XDG_CURRENT_DESKTOP set to Hyprland
20:32:10 xdg-desktop-portal-hyprland[106229]: [LOG] [screencopy] init successful
```

The new helper was extracted from the installer heredoc and exercised directly,
both branches:

- healthy session, no marker → exits in ~1 s, `xdg-desktop-portal` PID unchanged
- marker present → marker consumed, `xdg-desktop-portal` `110067 → 117844`,
  `xdg-desktop-portal-hyprland` re-activated as `117858`,
  `XDG_CURRENT_DESKTOP set to Hyprland`, all three portal units `active`

`bash -n` passes on the installer and on all three generated scripts
(`switch-to-desktop`, `deckshift-portal-recovery`, `gamescope-session-nm-wrapper`).

**Not yet exercised end to end:** a full Gaming Mode round-trip with the patched
installer applied. The individual pieces are verified, but the marker-survives-
teardown path can only really be proven by entering and leaving Gaming Mode once
with these changes installed.

## Notes for the maintainer

- The README troubleshooting entry documented the old (incorrect) root cause and
  a manual workaround that no longer applies; updated to match. It references
  **v0.2.1** as the version carrying the fix — adjust to whatever you tag.
- `NOTES.md` items 2 and 3 under the return-from-Gaming-Mode history describe the
  stale-HIS theory and the pipewire ordering rationale. Both are superseded by
  this, but I left your working notes alone rather than rewriting your log.
