### PR TITLE
Optional capture session log and quieter NVIDIA install

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Use **`[hybrid-nvidia]`** in the control panel instead. Gamescope will run on th
 
 ## Bootloader Support
 
-the installer enables NVIDIA DRM modeset via:
+The installer enables NVIDIA DRM modeset via:
 
 - `/etc/modprobe.d/nvidia.conf` — `options nvidia_drm modeset=1`
 - `/etc/mkinitcpio.conf.d/nvidia.conf` — `MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)`

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Lineage: forked from Super-Shift-S-Omarchy-Deck-Mode, briefly renamed Omarchy De
 
 ## What's New
 
-### v0.2.2 — Opt-in session logs from the control panel
+### v0.2.2 — Opt-in session logs, quieter NVIDIA install, honest `--verify`
 
-Gaming Mode tears down Hyprland, so session output used to vanish with the desktop. The panel now has a **Capture session** toggle: when it's on, `switch-to-gaming` and the gamescope wrapper write a dated log under `~/.local/state/omarchy/nosignal.deckshift/` (the 10 newest are kept). **View** opens the default terminal on the latest file and `cat`s it.
+Gaming Mode tears down Hyprland, so session output used to vanish with the desktop. The panel now has a **Capture session** toggle: when it's on, `switch-to-gaming` and the gamescope wrapper write a dated log under `~/.local/state/omarchy/nosignal.deckshift/` (the 10 newest are kept). **View** opens the default terminal on the latest file and `cat`s it. Uninstall removes that folder too.
+
+If Omarchy had already enabled NVIDIA DRM modeset, the installer still warned it was missing and failed to notice Limine — then asked you to edit a bootloader config you did not need to touch. It now recognises that setup, and only offers to enable modeset the Omarchy way if it really is off. `--verify` no longer reports you missing the `video` / `input` / `wheel` groups just because you have not logged out yet; it will still remind you that a new login is what actually applies them.
 
 ### v0.2.1 — Fresh installs no longer fail on removed multilib packages
 
@@ -308,7 +310,7 @@ The installer detects:
 
 - **AMD dGPU**: PCI device names (Navi, RDNA, Vega discrete cards)
 - **AMD APU**: integrated GPU codenames (Phoenix, Rembrandt, Van Gogh, etc.)
-- **NVIDIA**: lspci, configures `nvidia-drm.modeset=1` if missing, picks `nvidia-utils` vs `nvidia-580xx-utils` via Omarchy's GSP-firmware detection
+- **NVIDIA**: lspci, enables DRM modeset the Omarchy way (`/etc/modprobe.d/nvidia.conf` + mkinitcpio modules) if missing, picks `nvidia-utils` vs `nvidia-580xx-utils` via Omarchy's GSP-firmware detection
 - **Intel (Arc / Iris Xe / iGPU)**: `i915` / `xe` kernel drivers
 - **Hybrid combinations**: detected by the control panel, which surfaces the appropriate `[hybrid-*]` GPU mode
 
@@ -375,7 +377,7 @@ DXVK_STATE_CACHE=1
 
 ## NVIDIA-Specific Notes
 
-- **Kernel parameter**: `nvidia-drm.modeset=1` is required. The installer can configure this for Limine, GRUB, or systemd-boot.
+- **DRM modeset**: required so Gamescope can take over the display. The installer treats it as already on if `/sys/module/nvidia_drm/parameters/modeset` is `Y`, Omarchy's `/etc/modprobe.d/nvidia.conf` has `options nvidia_drm modeset=1`, or the kernel cmdline has `nvidia-drm.modeset=1` (any bootloader). If missing, it writes the same two files and rebuilds the initramfs (`limine-mkinitcpio` on Limine/UKI, `mkinitcpio -P` otherwise).
 - **Resolution cap**: Gamescope on NVIDIA is limited to 2560×1440 maximum.
 - **Force composition**: the NVIDIA wrapper automatically adds `--force-composition` if your Gamescope version supports it.
 - **Environment**: `GBM_BACKEND=nvidia-drm` and related vars are set automatically.
@@ -389,13 +391,12 @@ Use **`[hybrid-nvidia]`** in the control panel instead. Gamescope will run on th
 
 ## Bootloader Support
 
-The installer can automatically configure `nvidia-drm.modeset=1` for:
+the installer enables NVIDIA DRM modeset via:
 
-- **Limine** — appends to `cmdline:` in `/boot/limine.conf`
-- **GRUB** — adds to `GRUB_CMDLINE_LINUX_DEFAULT` and regenerates config
-- **systemd-boot** — provides manual instructions for `/boot/loader/entries/*.conf`
+- `/etc/modprobe.d/nvidia.conf` — `options nvidia_drm modeset=1`
+- `/etc/mkinitcpio.conf.d/nvidia.conf` — `MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)`
 
-A backup is created before any bootloader modification.
+That works with Limine (Omarchy default), GRUB, or systemd-boot. The installer still detects which bootloader you use so it can rebuild the initramfs correctly.
 
 ## Troubleshooting
 
@@ -420,7 +421,7 @@ See [Recovery from a Black Screen](#recovery-from-a-black-screen) for how to get
 
 **Gaming Mode doesn't start**
 
-- Check NVIDIA kernel params: `cat /proc/cmdline | grep nvidia`
+- Check NVIDIA DRM modeset: `cat /sys/module/nvidia_drm/parameters/modeset` (expect `Y`) or `cat /etc/modprobe.d/nvidia.conf`
 - Verify gamescope works: `gamescope -- steam`
 - Check session logs: `journalctl --user -u gamescope-session -n 50`
 
@@ -544,6 +545,7 @@ sudo rm -f /etc/NetworkManager/conf.d/20-unmanaged-systemd.conf
 # Remove user files
 rm -f ~/.config/environment.d/gamescope-session-plus.conf
 rm -rf ~/.cache/deckshift
+rm -rf "${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/nosignal.deckshift"
 
 # Remove the control panel plugin and its shell.json wiring
 rm -rf ~/.config/omarchy/plugins/nosignal.deckshift
@@ -575,7 +577,7 @@ yay -Rns gamescope-session-git gamescope-session-steam-git
 
 ## Changelog
 
-- **v0.2.2** — Opt-in Gaming Mode session logs from the control panel: capture toggle writes dated logs under `~/.local/state/omarchy/nosignal.deckshift/` (10 newest kept); View cats the latest in the default terminal.
+- **v0.2.2** — Opt-in Gaming Mode session logs from the control panel (dated files under `~/.local/state/omarchy/nosignal.deckshift/`, 10 newest kept). NVIDIA DRM modeset is detected via Omarchy's modprobe/sysfs (not only `/proc/cmdline`) and enabled with the same `nvidia.conf` drop-ins + initramfs rebuild, any bootloader. `--verify` reads `/etc/group` for `video`/`input`/`wheel` so group checks pass without logging out. Uninstall removes the session-log state directory.
 - **v0.2.1** — Fix fresh installs failing with "target not found": dropped `lib32-openal`, `lib32-sdl2-compat` and `lib32-libvdpau` (removed from Arch multilib); installer now skips repo-dropped packages instead of aborting.
 - **v0.2.0** — Native Omarchy 4 control panel (bar icon + panel, `Super+Alt+G`) replaces the gum settings TUI; saved settings now actually reach the running session (`set-environment` fix); Launch Gaming Mode from the panel behind a confirm.
 - **v0.1.15** — Omarchy 4 compatibility: keybind and portal-recovery autostart moved to the Lua config files (`bindings.lua` / `autostart.lua`, `.conf` fallback for pre-4); Walker/elephant integration removed. *(v0.1.14 was an unreleased keybind change that was reverted; the number is skipped.)*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeckShift
 
-**Version 0.2.1** — Steam Deck-style gaming mode for [Omarchy](https://omarchy.com). Press `Super+Shift+S` to enter Gaming Mode (Steam Big Picture in Gamescope), `Super+Shift+R` to return to your desktop — or drive the whole thing from the control panel in your bar (`Super+Alt+G`).
+**Version 0.2.2** — Steam Deck-style gaming mode for [Omarchy](https://omarchy.com). Press `Super+Shift+S` to enter Gaming Mode (Steam Big Picture in Gamescope), `Super+Shift+R` to return to your desktop — or drive the whole thing from the control panel in your bar (`Super+Alt+G`).
 
 Lineage: forked from Super-Shift-S-Omarchy-Deck-Mode, briefly renamed Omarchy Deck, then renamed DeckShift.
 
@@ -9,6 +9,10 @@ Lineage: forked from Super-Shift-S-Omarchy-Deck-Mode, briefly renamed Omarchy De
 [![DeckShift demo](https://img.youtube.com/vi/nj4pLh3spCs/maxresdefault.jpg)](https://youtu.be/nj4pLh3spCs)
 
 ## What's New
+
+### v0.2.2 — Opt-in session logs from the control panel
+
+Gaming Mode tears down Hyprland, so session output used to vanish with the desktop. The panel now has a **Capture session** toggle: when it's on, `switch-to-gaming` and the gamescope wrapper write a dated log under `~/.local/state/omarchy/nosignal.deckshift/` (the 10 newest are kept). **View** opens the default terminal on the latest file and `cat`s it.
 
 ### v0.2.1 — Fresh installs no longer fail on removed multilib packages
 
@@ -94,7 +98,7 @@ After install, open the control panel (bar icon or `Super+Alt+G`) and pick:
 - A resolution / refresh rate
 - A GPU mode — for hybrid laptops, prefer `[hybrid-nvidia]` or `[hybrid-amd]` over the direct options
 
-Press **Save**, then **Launch Gaming Mode** (or `Super+Shift+S`).
+Press **Save**, then **Launch Gaming Mode** (or `Super+Shift+S`). Turn on **Capture session** in the panel first if you want a log of that run (kept under `~/.local/state/omarchy/nosignal.deckshift/`, 10 newest).
 
 > Already-running shells won't show the panel until you run `omarchy-restart-shell` once.
 
@@ -107,6 +111,8 @@ Press **Save**, then **Launch Gaming Mode** (or `Super+Shift+S`).
 | Return to Desktop (alternative) | Steam → Power → **Switch to Desktop** |
 | Open control panel | Bar icon, `Super + Alt + G`, or `omarchy-shell shell toggle nosignal.deckshift` |
 | Launch Gaming Mode from panel | **Launch Gaming Mode** button (confirms first) |
+| Capture a session log | Panel **Capture session** toggle, then launch. Logs land in `~/.local/state/omarchy/nosignal.deckshift/` (10 newest kept) |
+| Open session logs | **View** in the panel (terminal `cat` of the newest session log) |
 
 ### Command-Line Options
 
@@ -488,6 +494,7 @@ If you're on AC and using Omarchy, this is expected — see the *Performance Mod
 
 | Component | Command |
 |---|---|
+| Session files (opt-in from the panel) | `~/.local/state/omarchy/nosignal.deckshift/session-*.log` (10 newest) |
 | Gaming session | `journalctl --user -u gamescope-session` |
 | NetworkManager | `journalctl -t gamescope-nm` |
 | Drive mounting | `journalctl -t steam-library-mount` |
@@ -568,6 +575,7 @@ yay -Rns gamescope-session-git gamescope-session-steam-git
 
 ## Changelog
 
+- **v0.2.2** — Opt-in Gaming Mode session logs from the control panel: capture toggle writes dated logs under `~/.local/state/omarchy/nosignal.deckshift/` (10 newest kept); View cats the latest in the default terminal.
 - **v0.2.1** — Fix fresh installs failing with "target not found": dropped `lib32-openal`, `lib32-sdl2-compat` and `lib32-libvdpau` (removed from Arch multilib); installer now skips repo-dropped packages instead of aborting.
 - **v0.2.0** — Native Omarchy 4 control panel (bar icon + panel, `Super+Alt+G`) replaces the gum settings TUI; saved settings now actually reach the running session (`set-environment` fix); Launch Gaming Mode from the panel behind a confirm.
 - **v0.1.15** — Omarchy 4 compatibility: keybind and portal-recovery autostart moved to the Lua config files (`bindings.lua` / `autostart.lua`, `.conf` fallback for pre-4); Walker/elephant integration removed. *(v0.1.14 was an unreleased keybind change that was reverted; the number is skipped.)*

--- a/deckshift.sh
+++ b/deckshift.sh
@@ -39,7 +39,7 @@ set -Euo pipefail
 # -u: Treat unset variables as errors (catches typos in variable names)
 # -o pipefail: A pipeline fails if ANY command in it fails, not just the last one
 
-DECKSHIFT_VERSION="0.2.1"
+DECKSHIFT_VERSION="0.2.2"
 
 # Plugin id for the omarchy-shell control panel. Must match the "id" in
 # plugins/<id>/manifest.json — the shell keys everything (shell.json entries,
@@ -2190,6 +2190,59 @@ NVIDIA_WRAPPER
 log() { logger -t gamescope-wrapper "$*"; echo "$*"; }
 
 SAVED_STATE_FILE="$HOME/.cache/deckshift/saved-state"
+DECKSHIFT_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/nosignal.deckshift"
+DECKSHIFT_CAPTURE="$DECKSHIFT_STATE/capture"
+DECKSHIFT_CURRENT="$DECKSHIFT_STATE/current"
+DECKSHIFT_LOG=""
+
+deckshift_capture_on() {
+    [[ -f "$DECKSHIFT_CAPTURE" ]]
+}
+
+deckshift_prune_logs() {
+    shopt -s nullglob
+    local files=("$DECKSHIFT_STATE"/session-*.log)
+    local n=${#files[@]}
+    (( n > 10 )) || return 0
+    local sorted
+    mapfile -t sorted < <(printf '%s\n' "${files[@]}" | sort)
+    local drop=$(( ${#sorted[@]} - 10 ))
+    local i
+    for (( i = 0; i < drop; i++ )); do
+        rm -f "${sorted[i]}"
+    done
+}
+
+# Opt-in file log for the panel. switch-to-gaming creates the dated file and
+# writes its path to `current`; we append. If this session started without
+# that preamble (SDDM autologin still on Gaming Mode), create one here.
+deckshift_begin_session_log() {
+    deckshift_capture_on || return 0
+    mkdir -p "$DECKSHIFT_STATE" || return 0
+    local log=""
+    if [[ -f "$DECKSHIFT_CURRENT" ]]; then
+        log=$(tr -d '\n' < "$DECKSHIFT_CURRENT")
+    fi
+    if [[ -z "$log" || ! -f "$log" ]]; then
+        log="$DECKSHIFT_STATE/session-$(date +%Y%m%d-%H%M%S).log"
+        printf '%s\n' "$log" > "$DECKSHIFT_CURRENT"
+        {
+            echo "=== DeckShift session ==="
+            echo "started: $(date -Iseconds)"
+            echo "user: ${USER:-}"
+            echo "note: wrapper created this log (no switch-to-gaming current file)"
+        } > "$log"
+        deckshift_prune_logs
+    fi
+    {
+        echo "=== gamescope session start ==="
+        echo "started: $(date -Iseconds)"
+    } >> "$log"
+    DECKSHIFT_LOG="$log"
+    exec >>"$log" 2>&1
+}
+
+deckshift_begin_session_log
 
 # Capture the user's actual pre-Gaming-Mode CPU governor + power profile so we
 # can restore those exact values on exit, instead of guessing "powersave/balanced"
@@ -2296,6 +2349,10 @@ cleanup() {
     sudo -n /usr/local/bin/gamescope-nm-stop 2>/dev/null || true
     restore_balanced_mode
     rm -f /tmp/.gaming-session-active
+    if [[ -n "$DECKSHIFT_LOG" ]]; then
+        echo "=== gamescope session end ===" >> "$DECKSHIFT_LOG" 2>/dev/null || true
+        sync -f "$DECKSHIFT_LOG" 2>/dev/null || sync
+    fi
 }
 trap cleanup EXIT INT TERM
 
@@ -2348,7 +2405,11 @@ export GTK_IM_MODULE=Steam
 export STEAM_DISABLE_AUDIO_DEVICE_SWITCHING=1
 export STEAM_ENABLE_VOLUME_HANDLER=1
 
-/usr/share/gamescope-session-plus/gamescope-session-plus steam
+if command -v stdbuf >/dev/null 2>&1; then
+    stdbuf -oL -eL /usr/share/gamescope-session-plus/gamescope-session-plus steam
+else
+    /usr/share/gamescope-session-plus/gamescope-session-plus steam
+fi
 rc=$?
 
 exit $rc
@@ -2416,6 +2477,43 @@ OS_SESSION_SELECT
 
   sudo tee "$switch_script" > /dev/null << 'SWITCH_SCRIPT'
 #!/bin/bash
+# Opt-in session log for the nosignal.deckshift panel. The flag lives in the
+# XDG state dir so it survives this Hyprland session dying at the SDDM restart.
+DECKSHIFT_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/nosignal.deckshift"
+DECKSHIFT_CAPTURE="$DECKSHIFT_STATE/capture"
+DECKSHIFT_CURRENT="$DECKSHIFT_STATE/current"
+if [[ -f "$DECKSHIFT_CAPTURE" ]]; then
+  mkdir -p "$DECKSHIFT_STATE"
+  DECKSHIFT_LOG="$DECKSHIFT_STATE/session-$(date +%Y%m%d-%H%M%S).log"
+  {
+    echo "=== DeckShift switch-to-gaming ==="
+    echo "started: $(date -Iseconds)"
+    echo "user: ${USER:-}"
+    ENV_CONF="$HOME/.config/environment.d/gamescope-session-plus.conf"
+    if [[ -f "$ENV_CONF" ]]; then
+      echo "--- gamescope-session-plus.conf ---"
+      cat "$ENV_CONF"
+      echo "---"
+    fi
+  } > "$DECKSHIFT_LOG"
+  printf '%s\n' "$DECKSHIFT_LOG" > "$DECKSHIFT_CURRENT"
+  shopt -s nullglob
+  prune_files=("$DECKSHIFT_STATE"/session-*.log)
+  prune_n=${#prune_files[@]}
+  if (( prune_n > 10 )); then
+    mapfile -t prune_sorted < <(printf '%s\n' "${prune_files[@]}" | sort)
+    prune_drop=$(( ${#prune_sorted[@]} - 10 ))
+    for (( prune_i = 0; prune_i < prune_drop; prune_i++ )); do
+      rm -f "${prune_sorted[prune_i]}"
+    done
+  fi
+  if command -v stdbuf >/dev/null 2>&1; then
+    exec > >(stdbuf -oL tee -a "$DECKSHIFT_LOG") 2>&1
+  else
+    exec > >(tee -a "$DECKSHIFT_LOG") 2>&1
+  fi
+fi
+
 # Inhibit suspend FIRST - prevents suspend when monitor detaches during switch
 sudo -n systemctl mask --runtime sleep.target suspend.target hibernate.target hybrid-sleep.target 2>/dev/null
 sudo -n /usr/local/bin/gaming-session-switch gaming 2>/dev/null || {
@@ -3138,6 +3236,26 @@ verify_installation() {
   if [[ -e /usr/local/bin/deckshift-settings ]]; then
     echo "  ⚠ old settings TUI still present at /usr/local/bin/deckshift-settings"
     echo "    (superseded by the panel — re-run the installer to remove it)"
+  fi
+
+  echo ""
+  echo "  SESSION LOG CAPTURE:"
+  echo "  --------------------"
+  local wrapper_bin="/usr/local/bin/gamescope-session-nm-wrapper"
+  local switch_bin="/usr/local/bin/switch-to-gaming"
+  if [[ -f "$wrapper_bin" ]] && grep -q "omarchy/nosignal.deckshift" "$wrapper_bin" \
+       && grep -q 'DECKSHIFT_CAPTURE' "$wrapper_bin"; then
+    echo "  ✓ session wrapper honors opt-in capture under ~/.local/state/omarchy/nosignal.deckshift"
+  else
+    echo "  ✗ session wrapper is missing capture logging — re-run the installer"
+    all_ok=false
+  fi
+  if [[ -f "$switch_bin" ]] && grep -q "omarchy/nosignal.deckshift" "$switch_bin" \
+       && grep -q 'DECKSHIFT_CAPTURE' "$switch_bin"; then
+    echo "  ✓ switch-to-gaming starts a dated session log when capture is on"
+  else
+    echo "  ✗ switch-to-gaming is missing capture logging — re-run the installer"
+    all_ok=false
   fi
 
   echo ""

--- a/deckshift.sh
+++ b/deckshift.sh
@@ -22,7 +22,7 @@
 #
 # It handles everything needed for this transformation:
 #   - Installing all Steam/gaming dependencies and GPU drivers
-#   - Configuring NVIDIA kernel parameters (nvidia-drm.modeset=1)
+#   - Configuring NVIDIA DRM modeset (Omarchy modprobe + mkinitcpio)
 #   - Setting up session switching between Hyprland and Gamescope via SDDM
 #   - Creating keybinds (Super+Shift+S to enter, Super+Shift+R to exit)
 #   - Configuring NetworkManager handoff (iwd <-> NM) for Steam network access
@@ -125,6 +125,19 @@ validate_environment() {
 # Quick check if a pacman package is installed. Used throughout the script
 # to avoid reinstalling things that are already present.
 check_package() { pacman -Qi "$1" &>/dev/null; }
+
+# Group membership: `id -nG USER` reads /etc/group, so it is correct right
+# after usermod. Bare `id -nG` / `groups` is this login session and stays
+# stale until logout.
+user_in_group_db() {
+  local user="${1:-$USER}"
+  local grp="$2"
+  id -nG "$user" 2>/dev/null | grep -qw "$grp"
+}
+
+user_in_group_session() {
+  id -nG 2>/dev/null | grep -qw "$1"
+}
 
 # Distinguishes AMD integrated GPUs (iGPUs/APUs) from discrete AMD GPUs (dGPUs).
 # This matters because Gaming Mode needs to target the RIGHT GPU — if you have
@@ -271,15 +284,40 @@ detect_dgpu_monitors() {
   done
 }
 
-# NVIDIA GPUs require a kernel parameter (nvidia-drm.modeset=1) to work
-# properly with Wayland compositors like Gamescope. Without it, the GPU
-# won't expose DRM (Direct Rendering Manager) devices, and Gamescope
-# won't be able to take over the display.
-#
-# This function checks if the parameter is already set in the running
-# kernel's command line (/proc/cmdline). If not, it detects the bootloader
-# (Limine, GRUB, or systemd-boot) and offers to add it automatically.
-# A reboot is required after adding the parameter.
+# NVIDIA GPUs need DRM KMS (modeset) so Wayland compositors like Gamescope
+# can take over the display. Omarchy enables this the same way on any
+# bootloader: a modprobe option plus nvidia modules in the initramfs
+# (see /usr/share/omarchy/install/hardware/nvidia.sh). A kernel cmdline
+# nvidia-drm.modeset=1 also counts if the user set it on Limine, GRUB, or
+# systemd-boot.
+nvidia_modeset_is_enabled() {
+  local modeset
+  if [[ -r /sys/module/nvidia_drm/parameters/modeset ]]; then
+    modeset=$(< /sys/module/nvidia_drm/parameters/modeset)
+    [[ "$modeset" == [Yy1]* ]] && return 0
+  fi
+  if grep -rqsE '^[[:space:]]*options[[:space:]]+nvidia_drm[[:space:]].*modeset=1' /etc/modprobe.d 2>/dev/null; then
+    return 0
+  fi
+  grep -qE "nvidia[-_]drm\.modeset=1" /proc/cmdline 2>/dev/null
+}
+
+# /boot is often 0700 on Omarchy (ESP), so tests under /boot use sudo.
+# Limine is checked first because it is Omarchy's default, but GRUB and
+# systemd-boot are valid if the user replaced it.
+detect_bootloader() {
+  if [[ -f /etc/default/limine ]] || [[ -d /etc/limine-entry-tool.d ]] \
+    || sudo test -f /boot/limine.conf || sudo test -f /boot/limine/limine.conf; then
+    echo limine
+  elif sudo test -d /boot/loader/entries; then
+    echo systemd-boot
+  elif [[ -f /etc/default/grub ]]; then
+    echo grub
+  else
+    echo unknown
+  fi
+}
+
 check_nvidia_kernel_params() {
   local lspci_output
   lspci_output=$(/usr/bin/lspci 2>/dev/null)
@@ -289,144 +327,124 @@ check_nvidia_kernel_params() {
 
   echo ""
   echo "================================================================"
-  echo "  NVIDIA KERNEL PARAMETER CHECK"
+  echo "  NVIDIA DRM MODESET CHECK"
   echo "================================================================"
   echo ""
 
-  if grep -qE "nvidia[-_]drm\.modeset=1" /proc/cmdline 2>/dev/null; then
-    info "nvidia-drm.modeset=1 is already configured"
+  if nvidia_modeset_is_enabled; then
+    info "NVIDIA DRM modeset is already enabled"
     return 0
   fi
 
-  warn "nvidia-drm.modeset=1 is NOT SET - required for Gaming Mode!"
+  warn "NVIDIA DRM modeset is NOT SET - required for Gaming Mode!"
   echo ""
 
-  local bootloader=""
-  local config_file=""
-
-  if [ -f /boot/limine.conf ]; then
-    bootloader="limine"; config_file="/boot/limine.conf"
-  elif [ -f /boot/limine/limine.conf ]; then
-    bootloader="limine"; config_file="/boot/limine/limine.conf"
-  elif [ -d /boot/loader/entries ]; then
-    bootloader="systemd-boot"
-  elif [ -f /etc/default/grub ]; then
-    bootloader="grub"
-  fi
-
+  local bootloader
+  bootloader=$(detect_bootloader)
   info "Detected bootloader: $bootloader"
-
-  case "$bootloader" in
-    limine)
-      info "Limine config: $config_file"
-      read -p "Add nvidia-drm.modeset=1 to Limine config? [Y/n]: " -n 1 -r
-      echo
-      if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-        configure_limine_nvidia "$config_file"
-      else
-        warn "Skipping - you'll need to add nvidia-drm.modeset=1 manually"
-        show_manual_nvidia_instructions
-      fi
-      ;;
-    systemd-boot)
-      echo ""
-      echo "  systemd-boot detected. You need to add nvidia-drm.modeset=1"
-      echo "  to your boot entry in /boot/loader/entries/*.conf"
-      echo ""
-      show_manual_nvidia_instructions
-      ;;
-    grub)
-      echo ""
-      read -p "Add nvidia-drm.modeset=1 to GRUB config? [Y/n]: " -n 1 -r
-      echo
-      if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-        configure_grub_nvidia
-      else
-        warn "Skipping - you'll need to add nvidia-drm.modeset=1 manually"
-        show_manual_nvidia_instructions
-      fi
-      ;;
-    *)
-      echo ""
-      warn "Could not detect bootloader type"
-      show_manual_nvidia_instructions
-      ;;
-  esac
-}
-
-# Adds nvidia-drm.modeset=1 to the Limine bootloader config.
-# Limine stores kernel command line parameters on lines starting with "cmdline:".
-# This appends the parameter to the end of that line. A backup is created first
-# in case something goes wrong.
-configure_limine_nvidia() {
-  local config_file="$1"
-
-  info "Backing up Limine config..."
-  sudo cp "$config_file" "${config_file}.backup.$(date +%Y%m%d%H%M%S)" || {
-    err "Failed to backup Limine config"
-    return 1
-  }
-
-  info "Adding nvidia-drm.modeset=1 to Limine cmdline..."
-
-  if sudo sed -i '/^[[:space:]]*cmdline:/ s/$/ nvidia-drm.modeset=1/' "$config_file"; then
-    if grep -q "nvidia-drm.modeset=1" "$config_file"; then
-      info "Successfully added nvidia-drm.modeset=1 to Limine config"
-      echo ""
-      echo "  ✓ Limine config updated"
-      echo "  ✓ Changes will take effect after reboot"
-      echo ""
-      NEEDS_REBOOT=1
-    else
-      err "Failed to add parameter - please add manually"
-      show_manual_nvidia_instructions
-    fi
+  echo ""
+  echo "  Omarchy enables this via /etc/modprobe.d/nvidia.conf and"
+  echo "  /etc/mkinitcpio.conf.d/nvidia.conf (works with any bootloader)."
+  echo ""
+  read -p "Enable NVIDIA DRM modeset (modprobe + mkinitcpio)? [Y/n]: " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+    configure_omarchy_nvidia_modeset "$bootloader"
   else
-    err "Failed to modify Limine config"
+    warn "Skipping - you'll need to enable NVIDIA DRM modeset manually"
     show_manual_nvidia_instructions
   fi
 }
 
-# Adds nvidia-drm.modeset=1 to GRUB's kernel parameters.
-# GRUB stores defaults in /etc/default/grub — after modifying it, grub-mkconfig
-# must be run to regenerate the actual boot config at /boot/grub/grub.cfg.
-configure_grub_nvidia() {
-  local grub_default="/etc/default/grub"
+# Writes the same two files as Omarchy's nvidia.sh, then rebuilds the
+# initramfs. Limine/UKI uses limine-mkinitcpio; GRUB, systemd-boot, and
+# unknown fall back to mkinitcpio -P. Does not edit bootloader cmdline.
+configure_omarchy_nvidia_modeset() {
+  local bootloader="$1"
+  local modprobe_file="/etc/modprobe.d/nvidia.conf"
+  local mkinit_file="/etc/mkinitcpio.conf.d/nvidia.conf"
 
-  info "Backing up GRUB config..."
-  sudo cp "$grub_default" "${grub_default}.backup.$(date +%Y%m%d%H%M%S)" || {
-    err "Failed to backup GRUB config"
+  sudo mkdir -p /etc/modprobe.d /etc/mkinitcpio.conf.d || {
+    err "Failed to create NVIDIA config directories"
+    show_manual_nvidia_instructions
     return 1
   }
 
-  info "Adding nvidia-drm.modeset=1 to GRUB..."
-
-  if ! grep -q "nvidia-drm.modeset=1" "$grub_default"; then
-    sudo sed -i 's/\(GRUB_CMDLINE_LINUX_DEFAULT="[^"]*\)/\1 nvidia-drm.modeset=1/' "$grub_default"
-
-    if grep -q "nvidia-drm.modeset=1" "$grub_default"; then
-      info "Regenerating GRUB config..."
-      sudo grub-mkconfig -o /boot/grub/grub.cfg || {
-        err "Failed to regenerate GRUB config"
-        return 1
-      }
-      info "Successfully configured GRUB for NVIDIA"
-      NEEDS_REBOOT=1
-    else
-      err "Failed to add parameter to GRUB"
+  if [[ -f "$modprobe_file" ]] && grep -qE '^[[:space:]]*options[[:space:]]+nvidia_drm[[:space:]].*modeset=1' "$modprobe_file"; then
+    info "$modprobe_file already has modeset=1"
+  elif [[ -f "$modprobe_file" ]]; then
+    info "Appending modeset=1 to $modprobe_file..."
+    printf '%s\n' 'options nvidia_drm modeset=1' | sudo tee -a "$modprobe_file" >/dev/null || {
+      err "Failed to update $modprobe_file"
       show_manual_nvidia_instructions
-    fi
+      return 1
+    }
+  else
+    info "Writing $modprobe_file..."
+    printf '%s\n' 'options nvidia_drm modeset=1' | sudo tee "$modprobe_file" >/dev/null || {
+      err "Failed to write $modprobe_file"
+      show_manual_nvidia_instructions
+      return 1
+    }
   fi
+
+  if [[ -f "$mkinit_file" ]] && grep -q 'nvidia_drm' "$mkinit_file"; then
+    info "$mkinit_file already loads nvidia_drm"
+  elif [[ -f "$mkinit_file" ]]; then
+    info "Appending nvidia modules to $mkinit_file..."
+    printf '%s\n' 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee -a "$mkinit_file" >/dev/null || {
+      err "Failed to update $mkinit_file"
+      show_manual_nvidia_instructions
+      return 1
+    }
+  else
+    info "Writing $mkinit_file..."
+    printf '%s\n' 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee "$mkinit_file" >/dev/null || {
+      err "Failed to write $mkinit_file"
+      show_manual_nvidia_instructions
+      return 1
+    }
+  fi
+
+  if [[ "$bootloader" == "limine" ]] && command -v limine-mkinitcpio >/dev/null 2>&1; then
+    info "Rebuilding initramfs with limine-mkinitcpio..."
+    sudo limine-mkinitcpio || {
+      err "limine-mkinitcpio failed"
+      show_manual_nvidia_instructions
+      return 1
+    }
+  else
+    info "Rebuilding initramfs with mkinitcpio -P..."
+    sudo mkinitcpio -P || {
+      err "mkinitcpio -P failed"
+      show_manual_nvidia_instructions
+      return 1
+    }
+  fi
+
+  info "NVIDIA DRM modeset configured — reboot required"
+  echo ""
+  echo "  ✓ /etc/modprobe.d/nvidia.conf"
+  echo "  ✓ /etc/mkinitcpio.conf.d/nvidia.conf"
+  echo "  ✓ initramfs rebuilt ($bootloader)"
+  echo ""
+  NEEDS_REBOOT=1
 }
 
 show_manual_nvidia_instructions() {
   cat <<'MSG'
   Manual configuration required:
-  Limine: Add nvidia-drm.modeset=1 to cmdline in /boot/limine.conf
-  systemd-boot: Add to options in /boot/loader/entries/*.conf
-  GRUB: Add to GRUB_CMDLINE_LINUX_DEFAULT, then run grub-mkconfig -o /boot/grub/grub.cfg
+    /etc/modprobe.d/nvidia.conf:
+      options nvidia_drm modeset=1
+    /etc/mkinitcpio.conf.d/nvidia.conf:
+      MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
+    Then rebuild: limine-mkinitcpio  (Limine/UKI)
+                 mkinitcpio -P      (GRUB, systemd-boot, or other)
+
+  A kernel cmdline nvidia-drm.modeset=1 on Limine, GRUB, or systemd-boot
+  is also sufficient if you already set it that way.
 MSG
-  warn "Gaming Mode may not work correctly without nvidia-drm.modeset=1"
+  warn "Gaming Mode may not work correctly without NVIDIA DRM modeset"
 }
 
 # Sets NVIDIA-specific environment variables needed for Gamescope to work
@@ -820,15 +838,15 @@ check_steam_config() {
 
   local missing_groups=()
 
-  if ! groups | grep -qw 'video'; then
+  if ! user_in_group_db "$USER" video; then
     missing_groups+=("video")
   fi
 
-  if ! groups | grep -qw 'input'; then
+  if ! user_in_group_db "$USER" input; then
     missing_groups+=("input")
   fi
 
-  if ! groups | grep -qw 'wheel'; then
+  if ! user_in_group_db "$USER" wheel; then
     missing_groups+=("wheel")
   fi
 
@@ -1238,7 +1256,7 @@ setup_xbox_controllers() {
   echo blacklist xpad | sudo tee /etc/modprobe.d/blacklist-xpad.conf >/dev/null
   echo hid_xpadneo | sudo tee /etc/modules-load.d/xpadneo.conf >/dev/null
 
-  if ! id -nG "$USER" | grep -qw input; then
+  if ! user_in_group_db "$USER" input; then
     sudo usermod -aG input "$USER"
     NEEDS_RELOGIN=1
     info "Added $USER to the input group (login required to take effect)"
@@ -1557,7 +1575,7 @@ setup_session_switching() {
     if [[ "$dgpu_type" == "NVIDIA" ]]; then
       err "NVIDIA GPU detected but no DRM card found!"
       echo ""
-      echo "  This usually means nvidia-drm.modeset=1 is not set."
+      echo "  This usually means NVIDIA DRM modeset is not enabled."
       echo "  The installer will configure this - please complete the setup"
       echo "  and REBOOT before running this section again."
       echo ""
@@ -3336,8 +3354,12 @@ verify_installation() {
     all_ok=false
   fi
 
-  if groups 2>/dev/null | grep -qw input; then
-    echo "  ✓ User in 'input' group"
+  if user_in_group_db "$USER" input; then
+    if user_in_group_session input; then
+      echo "  ✓ User in 'input' group"
+    else
+      echo "  ✓ User in 'input' group (log out for this session to pick it up)"
+    fi
   else
     echo "  ✗ User NOT in 'input' group (required for keybind)"
     keybind_ok=false
@@ -3378,16 +3400,24 @@ verify_installation() {
   echo ""
   echo "  USER GROUPS:"
   echo "  ------------"
-  local user_groups
-  user_groups=$(groups 2>/dev/null)
+  local needs_logout=false
   for grp in video input wheel; do
-    if echo "$user_groups" | grep -qw "$grp"; then
-      printf "  ✓ User is in '%s' group\n" "$grp"
+    if user_in_group_db "$USER" "$grp"; then
+      if user_in_group_session "$grp"; then
+        printf "  ✓ User is in '%s' group\n" "$grp"
+      else
+        printf "  ✓ User is in '%s' group (log out for this session to pick it up)\n" "$grp"
+        needs_logout=true
+      fi
     else
       printf "  ✗ User is NOT in '%s' group\n" "$grp"
       all_ok=false
     fi
   done
+  if $needs_logout; then
+    echo "  → Group membership is saved; Super+Shift+R / passwordless session"
+    echo "    switch need a new login before they apply."
+  fi
 
   echo ""
   echo "  SERVICE STATUS:"
@@ -3447,7 +3477,7 @@ verify_installation() {
 #   1. Authenticate sudo (and clear cached credentials first for a fresh prompt)
 #   2. Validate we're on an Omarchy system
 #   3. Install Steam dependencies and GPU drivers
-#   4. Configure NVIDIA kernel parameters (if applicable)
+#   4. Configure NVIDIA DRM modeset (if applicable)
 #   5. Set NVIDIA environment variables (if applicable)
 #   6. Install script requirements and performance permissions
 #   7. Set up session switching (the big one — all the scripts and configs)
@@ -3483,8 +3513,8 @@ execute_setup() {
     echo "  IMPORTANT: REBOOT REQUIRED"
     echo "================================================================"
     echo ""
-    echo "  Bootloader configuration has been updated (nvidia-drm.modeset=1)."
-    echo "  You MUST reboot for the kernel parameter to take effect."
+    echo "  Boot-time configuration was updated (NVIDIA DRM modeset and/or drivers)."
+    echo "  You MUST reboot for it to take effect."
     echo ""
     if [ "$NEEDS_RELOGIN" -eq 1 ]; then
       echo "  Additionally, user groups were updated (video/input/wheel)."

--- a/plugins/nosignal.deckshift/Panel.qml
+++ b/plugins/nosignal.deckshift/Panel.qml
@@ -63,6 +63,19 @@ Item {
   property string saveError: ""
   property bool saving: false
 
+  // Opt-in session logs. The flag and files live under XDG state so they
+  // survive the SDDM restart that kills this panel. Capture is written the
+  // moment the toggle flips — Save-buffering would miss Super+Shift+S.
+  property bool captureEnabled: false
+  property int sessionCount: 0
+
+  readonly property string stateDir: {
+    var xdg = Quickshell.env("XDG_STATE_HOME")
+    var home = Quickshell.env("HOME") || ""
+    var rootDir = (xdg && xdg !== "") ? xdg : (home + "/.local/state")
+    return rootDir + "/omarchy/" + root.selfId
+  }
+
   // Keys the GPU dropdown owns. Cleared as a set on every GPU pick so
   // switching modes never leaves a stale flag behind — same list, same reason
   // as the TUI's GPU_MODE_KEYS.
@@ -160,6 +173,7 @@ Item {
     root.pendingSet = ({})
     root.pendingUnset = ({})
     fetchProc.running = true
+    sessionListProc.running = true
   }
 
   // ---------------------------------------------------- pending-edit buffer
@@ -638,6 +652,64 @@ Item {
     onExited: function(exitCode) { root.saveFinished(exitCode, saveOut.text) }
   }
 
+  // ---------------------------------------------------------- session logs
+
+  // Two lines: capture flag, then the number of session-*.log files.
+  readonly property string sessionListScript: [
+    'dir="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/nosignal.deckshift"',
+    '[ -f "$dir/capture" ] && echo true || echo false',
+    'shopt -s nullglob',
+    'files=("$dir"/session-*.log)',
+    'echo ${#files[@]}'
+  ].join("\n")
+
+  function parseSessions(text) {
+    var lines = String(text || "").split("\n")
+    root.captureEnabled = String(lines[0] || "").trim() === "true"
+    var n = parseInt(String(lines[1] || "0").trim(), 10)
+    root.sessionCount = (n > 0) ? n : 0
+  }
+
+  Process {
+    id: sessionListProc
+    command: ["sh", "-c", root.sessionListScript]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.parseSessions(text)
+    }
+  }
+
+  readonly property string captureWriteScript: [
+    'on="$1"',
+    'dir="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/nosignal.deckshift"',
+    'mkdir -p "$dir" || exit 1',
+    'if [ "$on" = "1" ]; then echo 1 > "$dir/capture"; else rm -f "$dir/capture"; fi'
+  ].join("\n")
+
+  function setCapture(on) {
+    root.captureEnabled = on
+    Quickshell.execDetached(["sh", "-c", root.captureWriteScript, "deckshift-capture", on ? "1" : "0"])
+  }
+
+  function openSessionDir() {
+    // Default terminal at the log dir, cat the newest session-*.log, then
+    // drop into a shell so the window doesn't vanish. uwsm-app +
+    // xdg-terminal-exec is how Omarchy itself opens terminals.
+    Quickshell.execDetached(["sh", "-c", [
+      'dir="$1"',
+      'mkdir -p "$dir" || exit 1',
+      'shopt -s nullglob',
+      'files=("$dir"/session-*.log)',
+      'if (( ${#files[@]} > 0 )); then',
+      '  latest=$(printf \'%s\\n\' "${files[@]}" | sort | tail -n1)',
+      '  inner="cat $(printf %q "$latest"); echo; exec bash"',
+      'else',
+      '  inner=\'echo "No session logs yet."; exec bash\'',
+      'fi',
+      'setsid uwsm-app -- xdg-terminal-exec --dir="$dir" -e bash -c "$inner"'
+    ].join("\n"), "deckshift-sessions", root.stateDir])
+  }
+
   // ---------------------------------------------------------------- launch
 
   // Raise the confirm and take the keyboard back off whichever dropdown
@@ -918,7 +990,64 @@ Item {
             }
           }
 
+          // ---- session log --------------------------------------------------
+          Column {
+            width: parent.width
+            spacing: root.rowSpacing
+
+            PanelSeparator { foreground: root.foreground }
+
+            PanelSectionHeader {
+              text: "SESSION LOG"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+            }
+
+            Item {
+              width: parent.width
+              height: Math.max(captureSwitch.implicitHeight, viewSessionsButton.implicitHeight)
+
+              Row {
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Style.spacing.lg
+
+                Text {
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: "Capture session"
+                  color: root.foreground
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.subtitle
+                }
+
+                ToggleSwitch {
+                  id: captureSwitch
+                  anchors.verticalCenter: parent.verticalCenter
+                  checked: root.captureEnabled
+                  foreground: root.foreground
+                  accent: root.accent
+                  onToggled: root.setCapture(!root.captureEnabled)
+                }
+              }
+
+              Button {
+                id: viewSessionsButton
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                text: "View"
+                bordered: true
+                foreground: root.foreground
+                accent: root.accent
+                fontFamily: root.fontFamily
+                opacity: root.sessionCount > 0 ? 1.0 : 0.4
+                onClicked: root.openSessionDir()
+              }
+            }
+          }
+
           // ---- actions ------------------------------------------------------
+          PanelSeparator { foreground: root.foreground }
+
           Item {
             width: parent.width
             height: launchButton.implicitHeight + card.contentBottomInset

--- a/plugins/nosignal.deckshift/manifest.json
+++ b/plugins/nosignal.deckshift/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "nosignal.deckshift",
   "name": "DeckShift",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "author": "Gavin Nugent",
   "license": "MIT",
   "description": "Gaming Mode control panel: pick the monitor, resolution, refresh rate and GPU gamescope launches with, then drop into Gaming Mode without leaving the desktop. Summon with: omarchy-shell shell toggle nosignal.deckshift",


### PR DESCRIPTION
I was sorting out some issues on my machine and it was handy to look at the output from the steam session, so I added an optional toggle to save the output of the last 10 sessions.

I also noticed that the installer was not correctly detecting that I had the drm modeset enabled.

Then when  prompted to verify after running the install, it was saying I was not part of the video group (I was), so I updated that to check for real membership, but still warn the user they need to re-login.


## Summary

v0.2.2 on `optional-capture-session-log` vs `master` (v0.2.1). Three commits: `5e66cf7` session logs, `602b12f` NVIDIA/groups, `0b0ca42` README typo.

**Files:** `deckshift.sh`, `README.md`, `plugins/nosignal.deckshift/Panel.qml`, `plugins/nosignal.deckshift/manifest.json`  
**Version:** `0.2.1` → `0.2.2`

## 1. Opt-in session logs (`5e66cf7`)

**Panel** (`Panel.qml`): Capture toggle + View. State dir is `${XDG_STATE_HOME:-~/.local/state}/omarchy/nosignal.deckshift/` (The files it creates are:`capture` flag, `session-*.log`, `current`). View opens the default terminal and `cat`s the newest log. `manifest.json` description updated.

**Installed scripts** (only if session-switching setup runs): `switch-to-gaming` dumps conf and tees stdout when `capture` exists; `gamescope-session-nm-wrapper` appends gamescope/Steam output and prunes to 10 logs.

**`--verify`:** greps `DECKSHIFT_CAPTURE` in those two binaries.

This is SDDM → wrapper, not `gamescope-session.service`. Capture includes the `switch-to-gaming` preamble the journal does not.

<img width="487" height="254" alt="image" src="https://github.com/user-attachments/assets/5c9f45a8-ec9d-4601-92cd-0d16cd23e268" />

## 2. NVIDIA DRM modeset (`602b12f`)

**Removed:** `sed` on Limine `cmdline:` / GRUB `GRUB_CMDLINE_LINUX_DEFAULT`; `configure_limine_nvidia` / `configure_grub_nvidia`; “backup bootloader config” path.

**Added:**

- `nvidia_modeset_is_enabled` — sysfs `nvidia_drm` modeset `Y`/`1`, or `options nvidia_drm modeset=1` under `/etc/modprobe.d`, or cmdline `nvidia-drm.modeset=1`
- `detect_bootloader` — Limine (`/etc/default/limine`, `limine-entry-tool.d`, `sudo test` `/boot/limine.conf`), then systemd-boot, then GRUB (for **initramfs rebuild only**)
- `configure_omarchy_nvidia_modeset` — same files as Omarchy `nvidia.sh`; `limine-mkinitcpio` vs `mkinitcpio -P`; append if the file exists without the option

Skip the prompt if modeset is already on (typical Omarchy NVIDIA box).

## 3. Group checks without logging out (`602b12f`)

`user_in_group_db` = `id -nG "$USER"` (`/etc/group`). `user_in_group_session` = live `id -nG`.

Used by the installer add-check (`video`/`input`/`wheel`), Xbox `input` add, and `--verify`. Verify: in DB but not this session → check plus “log out for this session”; fail only if missing from `/etc/group`.

## 4. Docs (`README.md`, including `0b0ca42`)

What’s New v0.2.2 (user-facing). Changelog has paths / `id -nG` / rebuild commands. NVIDIA notes no longer say we edit bootloader cmdline. Uninstall: `rm -rf "${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/nosignal.deckshift"`. Troubleshooting: check sysfs/modprobe, not only `/proc/cmdline`.

## Maintainer checks

| Claim | Where to look |
| --- | --- |
| No Limine/GRUB `sed` | `configure_limine_nvidia` / `configure_grub_nvidia` gone from `deckshift.sh` |
| Omarchy enable path | `configure_omarchy_nvidia_modeset`, match `/usr/share/omarchy/install/hardware/nvidia.sh` |
| Modeset already on | `nvidia_modeset_is_enabled` before any prompt |
| Groups without logout | `--verify` USER GROUPS uses `user_in_group_db` |
| Capture opt-in | Panel writes `…/capture`; scripts no-op without that file |
| Logs not in `environment.d` | state dir only; `gamescope-session-plus.conf` unchanged |
| Uninstall cleans logs | README Uninstalling `rm -rf` that state dir |
| Skip “session switching” | does **not** refresh wrapper/`switch-to-gaming`; old binaries keep old capture behavior |

Full set: `git diff master...HEAD` on those four files.

## Test plan

- [x] Omarchy NVIDIA: installer reports modeset already enabled; no Limine/GRUB edit prompt
- [x] `--verify` after `usermod` without logout: groups show as present, with logout note if session is stale
- [x] Panel Capture on → Launch Gaming Mode → dated log under state dir; View cats newest; prune at 10
- [x] Capture off → no new session log
- [x] Uninstall instructions include removing the state directory